### PR TITLE
Make Jinja variable regex lazy

### DIFF
--- a/yaml_shellcheck.py
+++ b/yaml_shellcheck.py
@@ -277,7 +277,7 @@ def get_ansible_scripts(data):
                     # we cannot evaluate Jinja templates
                     # at least try to be useful and replace every expression with a variable
                     # we do not handle Jinja statements like loops of if/then/else
-                    script = re.sub(r"{{.*}}", "$JINJA_EXPRESSION", script)
+                    script = re.sub(r"{{.*?}}", "$JINJA_EXPRESSION", script)
 
                     # try to add shebang line from 'executable' if it looks like a shell
                     executable = task.get("args", {}).get("executable", None)


### PR DESCRIPTION
Thank you for merging the other PRs!

The current regex makes incorrect replacements sometimes, for example if there's a string `{{ var1 }} {{ var 2 }}`, the regex will replace this with `$JINJA_EXPRESSION` instead of the correct replacement `$JINJA_EXPRESSION $JINJA_EXPRESSION`.

This change makes the regex lazy so it'll only match one variable at a time.