### PR TITLE
ci: improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y shellcheck \
   && rm -rf /var/lib/apt/lists/*
 
+# prevent 9Mb of cached bytecode files (.pyc)
+ENV PYTHONDONTWRITEBYTECODE=1
+
 COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-compile --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY yaml_shellcheck.py .
 
+USER 1000
 ENTRYPOINT [ "python3", "yaml_shellcheck.py"]


### PR DESCRIPTION
I consider my Dockerfile here to be an example for development. It is not meant for production or something like a security-conscious CI-pipeline.

And still, the old one was a little too awful. So now I

- removed many pip and python cache files
- changed to a non-root user
- only copy required files, and not the full repo content
