### PR TITLE
fix(docs): GitLab CI example fails with "no such file"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ lint_yaml_shellcheck:
     name: quay.io/mschuette/yaml-shellcheck:latest
     entrypoint: [""]
   script:
-    - find . -name \*.yaml -or -name \*.yml | xargs python3 yaml_shellcheck.py
+    - find . -name \*.yaml -or -name \*.yml | xargs python3 /app/yaml_shellcheck.py
 ```
 
 ## File Formats


### PR DESCRIPTION
Using the docker image (`v1.6.0`) in GitLab CI with the README provided example fails with a file not found error, since the working directory defaults to a checked out repository directory.

Setting the path to the python filepath explicitly to `/app/yaml_shellcheck.py` resolves this issue

![image](https://github.com/user-attachments/assets/659f147d-a961-467e-bcd6-77dc719542c4)
