### PR TITLE
feat(Dockerfile): install shellcheck from the official docker image instead of apt package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y shellcheck \
-  && rm -rf /var/lib/apt/lists/*
+COPY --from=koalaman/shellcheck:v0.11.0 /bin/shellcheck /bin/
 
 # prevent 9Mb of cached bytecode files (.pyc)
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.13-slim
+FROM koalaman/shellcheck:v0.11.0 AS src
+FROM python:3.13-slim AS base
 
 WORKDIR /app
 
-COPY --from=koalaman/shellcheck:v0.11.0 /bin/shellcheck /bin/
+COPY --from=src /bin/shellcheck /bin/
 
 # prevent 9Mb of cached bytecode files (.pyc)
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Currently, the apt package is outdated (version 0.9.0 released in 2022) and does not support the latest shellcheck features. This change updates the Dockerfile to use the latest shellcheck release.

According to the official Docker image (https://hub.docker.com/r/koalaman/shellcheck), we could include shellcheck in our own docker image as follows:

```Dockerfile
FROM koalaman/shellcheck:stable

COPY --from=koalaman/shellcheck:stable /usr/bin/shellcheck /usr/bin/shellcheck
```

Instead of using a generic tag like `latest` or `stable`, we prefer to use a specific version tag (e.g., `v0.11.0`) to ensure consistency and avoid unexpected changes when the base image is updated. Like this, Dependatbot can help us keep track of new versions automatically.