### PR TITLE
fix: restore main function without required parameters

### DIFF
--- a/yaml_shellcheck.py
+++ b/yaml_shellcheck.py
@@ -533,7 +533,10 @@ def cleanup_files(args):
         logger.debug("removed working dir %s", args.outdir)
 
 
-def main(args):
+def main(args = None):
+    # pytest injects its args, a "normal" call should get them from command line
+    if not args:
+        args = setup()
     filenames = []
     for filename in args.files:
         try:
@@ -550,4 +553,4 @@ def main(args):
 
 if __name__ == "__main__":
     # exit with shellcheck exit code
-    sys.exit(main(setup()))
+    sys.exit(main())


### PR DESCRIPTION
fixes #39

This should restore the old interface as used/describe in tool.poetry.scripts to run main() without parameters.

But it also allows for the pytest calls to provide an args parameter (instead of parsing a command line with argparse).